### PR TITLE
Add support for posting build artifact URLs to PRs

### DIFF
--- a/.comment.sh
+++ b/.comment.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Copyright (C) 2018 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+#
+# Script for publishing built binaries to S3.
+
+set -e
+
+REPO="${PWD##*/}"
+BUCKET="${BUCKET:-rtklib-ci-builds}"
+PRS_BUCKET="${PRS_BUCKET:-rtklib-ci-builds}"
+
+BUILD_VERSION="$(git describe --tags --dirty --always)"
+
+if [ -z "$S3_PATH" ]; then
+  echo "Exiting... no \$S3_PATH specified..."
+  echo 0
+fi
+
+S3_PATH="$BUILD_VERSION/$S3_PATH"
+
+echo "Comment PULL_REQUEST ($TRAVIS_PULL_REQUEST)"
+echo "Comment BRANCH ($TRAVIS_BRANCH)"
+echo "Comment TAG ($TRAVIS_TAG)"
+
+if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+    if [[ "$TRAVIS_BRANCH" == master || "$TRAVIS_TAG" == v* || "$TRAVIS_BRANCH" == v*-release ]]; then
+        COMMENT="$S3_PATH
+https://console.aws.amazon.com/s3/home?region=us-west-2&bucket=$BUCKET&prefix=$S3_PATH/"
+        URL="https://slack.com/api/chat.postMessage?token=$SLACK_TOKEN&channel=$SLACK_CHANNEL"
+        DATA="text=$COMMENT"
+        if [ ! -z "$SLACK_CHANNEL" ]; then
+          curl --data-urlencode "$DATA" "$URL"
+        else
+          echo "Not posting to Slack, no \$SLACK_CHANNEL specified..."
+        fi
+    fi
+elif [ ! -z "$GITHUB_TOKEN" ]; then
+    COMMENT=\
+"## $BUILD_VERSION\n"\
+"+ [Artifacts (S3 / AWS Console)](https://console.aws.amazon.com/s3/home?region=us-west-2&bucket=rtklib-ci-builds&prefix=$S3_PATH/)\n"\
+"+ s3://$PRS_BUCKET/$S3_PATH"
+    URL="https://api.github.com/repos/swift-nav/$REPO/issues/$TRAVIS_PULL_REQUEST/comments"
+    curl -u "$GITHUB_TOKEN:" -X POST "$URL" -d "{\"body\":\"$COMMENT\"}"
+fi

--- a/.publish.sh
+++ b/.publish.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Copyright (C) 2016-2018 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+#
+# Script for publishing built binaries to S3.
+
+set -e
+
+REPO="${PWD##*/}"
+BUCKET="${BUCKET:-rtklib-ci-builds}"
+PRS_BUCKET="${PRS_BUCKET:-rtklib-ci-builds}"
+
+BUILD_VERSION="$(git describe --tags --dirty --always)"
+BUILD_PATH="$BUILD_VERSION"
+if [[ ! -z "$PRODUCT_VERSION" ]]; then
+    BUILD_PATH="$BUILD_PATH/$PRODUCT_VERSION"
+fi
+if [[ ! -z "$PRODUCT_REV" ]]; then
+    BUILD_PATH="$BUILD_PATH/$PRODUCT_REV"
+fi
+if [[ ! -z "$PRODUCT_TYPE" ]]; then
+    BUILD_PATH="$BUILD_PATH/$PRODUCT_TYPE"
+fi
+
+echo "Uploading $@ to $BUILD_PATH"
+echo "Publish PULL_REQUEST ($TRAVIS_PULL_REQUEST)"
+echo "Publish BRANCH ($TRAVIS_BRANCH)"
+echo "Publish TAG ($TRAVIS_TAG)"
+
+for file in "$@"; do
+    KEY="$BUILD_PATH/$(basename $file)"
+    if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+        if [[ "$TRAVIS_BRANCH" == master || "$TRAVIS_TAG" == v* || "$TRAVIS_BRANCH" == v*-release ]]; then
+            OBJECT="s3://$BUCKET/$KEY"
+            aws s3 cp "$file" "$OBJECT"
+        fi
+    else
+        OBJECT="s3://$PRS_BUCKET/$KEY"
+        aws s3 cp "$file" "$OBJECT"
+    fi
+done

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,22 @@ language: c
 matrix:
   include:
    - os: linux
+     before_install:
+      - pip install --user --upgrade awscli
    - os: osx 
      osx_image: Xcode 8.2
+     before_install:
+       - brew install awscli
 
 script:
   - (cd ./app/convbin/gcc/ && make clean all test)
 
-addons:
-  artifacts:
-    debug: true 
-    paths:
-      - ./app/convbin/gcc/sbp2rinex
-    working_dir: $TRAVIS_BUILD_DIR
-    target_paths: $TRAVIS_BUILD_NUMBER$TRAVIS_OS_NAME
-    bucket: rtklib-ci-builds
-    s3_region: us-west-2
+after_success:
+  - PRODUCT_VERSION=$TRAVIS_BUILD_NUMBER-$TRAVIS_OS_NAME ./.publish.sh app/convbin/gcc/sbp2rinex
+  - S3_PATH=$TRAVIS_BUILD_NUMBER-$TRAVIS_OS_NAME ./.comment.sh
+
+env:
+  global:
+    - secure: "eg8RavBDMlfvtxDquSL+yOibciC+T4Tju5Iueht/ltrOYsM6eJsiy8Ci6PLDnoeBc2v75aF39XNL4Zeo5xHJMESolVoUQ5CRp1lv2ttQjayPLHMTmVgpDOf+HZQQGYXQ3sjxQa/HNQh1xAiNS2YjbHMOLLnHbHquVFLvnbjMgoRdqPyMhL69Z9gP/W4QNWtH6GYfMBJ6aVsPaYvreCa4oYfsy3pm3CyHsoFiMrbkskusJUAn5Sb/4sDoREv6tOrmEujW+NyDBB4S/EzAc78T38YfKfsZGsC3ek0/1qSzoxZHZm0mjJi2F1qwObMNImiJX9UZhDve7slgdQUEpxpajQO28cEtza6RMBV6cqURj5Q/X5CYYfu3z7RRhcRbBkww+dChXKBoLAJOPxUC0J0AMXUYrI++WodoGt/ohM9th0i4Zcr/dtY7k+v83t+Ho+nvbh27RAA6VaObCZTML8JFqS1vabi9d4om9ZbYyRCNXi7ijvK2rKbUXHyRiHOb1bAzAmej5Sziy7URM82kKgP5PHQ4ybbbIfLYqimXvAc5osfczr3ig5yYhRA2YJeyH+EGBtHBmswrWW7Y3+4JkjOIP2NYi2p3qBWl4usErtgIr61N2LajK4LI9C/5V+jzi3DOqAyAZy1iQA+ONx8x6y+iyjiWIIT01jrsjBuJ2MnR7gQ="
+    - secure: "d9xUmXB4fukP2/eQMke7nyKXhyGvJUfzCLRJBLp7yxkt6uZgw32OO8dn7qaxIJV+un3VXHdhZ3dIP7kxJnLe65O0idH0HcVz/cJ0X9RS7NVWhH5cja/npNvcNtme34Kkb4gggmpx/1LKsEMUJs/+Xd2bKHRgEZVyqN27wsinMU09Fe/nzt/jqp2dL2ioYIW6dFkkKhG+qbl26WmlCwm08V7/LxwIT3RD098uHLjpFhO9SIVMjEgDPmZnlolPRdXrSQBff35U+Mdsi0HOuZwpd4h5gcBH6YOq2Fq/xB+ypf6L5O1udXP0wlnDGJduSowVque9qDnqAFACSv9Dz12IT2kJUcU6e+mm9yhbzV6Z9tr091NAc/3vRfyXJ45cz/hTxe+6FItbM9RmrZCBuIcaE3e3OJlZ3QFp5byiKuhw1om/ueIzzj0Npe8SBCjyf0BEIA4sP+KpE+WwdvlA7FzxxL+XdnnQqtjxjHYzeEw5oWqqM6vDZN9DbYmq4zHDGPjxEMcdTn8XLHQGl5MQ6QeK62GI6EhKF6FTrFEfGOhnFNdus+VC1Dm9LWZcrhsAXoybQKCO9Wq8NTapE+fDDfXCxEXkvq8tV02oW5t682PNwJif+XasZZN7qXc2mp0E8naG6DPZUKCl8nOYEMwCl/s6iPyODqX3pYZnFWumfBcHdsE="
+    - secure: "IegmIVOvJKUAKTmogVG/u2fFmaMTj9eRQWK4NwQLMnC3Ai79zxqaaUUF/hUMoMduRKAtB1DsFRc6ykMmI6U/O36MQQDn0Od8v11OAROcq7HN89xMoibyEIDG+XjG+nsXHvSE3Mw/OrFC9yb69Xh0BTeDJI3M9RI3IHf5P+FdoJY+FJMImtUXTY8JDmIJbHSyrRhArLliHzBfp4IpirNNM0Ae8yYE0W/un3LNPAquIRQylZVeURPheNIOcnTd513Dxg7Ik9lOL6dAbpMzaTqu0fq1tGQmBgrWEenfRsfJWJxGX9hQwb1wIre3D2hm37qSQwG71oO5pkEIpq+2OvB4huXDEHudlZrCNY02ee6BiXfENdxa1VrfSIZgoFMDNa4lxB7qTYX0ZZCgSKYDHFdJlLQf9GYz1xyEhwJK0g4T7ZOC7EnX9ASN1OGfgV3uJuft9sr3gjoqjv0EA/SwDvCFNVAqXk2XYIsONQncBRgdMIEnSbdZnQFjER47bNDihmihNWCBfAxbIXB9oj5OYZWwaKDsC3o+A5q60rxuoqv/McQGmB2jbRoi89FhAo+J/pyiepTQZrslpmQkIpqp5+YgLuXoA8OsNPMRKqpYW144twnPnYIpyr7hBITjXZ0VjWAaBvf81DrdJgpWBfhIZ6HLCPqSCHQ+2tGcPgG4odrhgPw="


### PR DESCRIPTION
Adapted scripts from piksi_buildroot to a comment to PRs when a build artifact is ready, and upload build artifacts from PRs to S3 (which is not possible with travis by default).