### PR TITLE
allow tcpsvr:// to bind to a particular address

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -1079,6 +1079,9 @@ static int gentcp(tcp_t *tcp, int type, char *msg)
     tcp->addr.sin_port=htons(tcp->port);
     
     if (type==0) { /* server socket */
+
+        if (strlen(tcp->saddr) != 0)
+            tcp->addr.sin_addr.s_addr = inet_addr(tcp->saddr);
     
 #ifdef SVR_REUSEADDR
         /* multiple-use of server socket */


### PR DESCRIPTION
This allows us to do things like this:

    str2str -in tcpsvr://127.0.1.1:55555 -out tcpsvr://127.0.2.1:55555

Which would (potentially) allow us to avoid port conflicts on `127.0.0.1`.