### PR TITLE
Wide-lane ambiguity fixing for multi-constellation, L1/L2 or L1/L5

### DIFF
--- a/app/rnx2rtkp/rnx2rtkp.c
+++ b/app/rnx2rtkp/rnx2rtkp.c
@@ -57,6 +57,7 @@ static const char *help[]={
 " -c        forward/backward combined solutions [off]",
 " -i        instantaneous integer ambiguity resolution [off]",
 " -h        fix and hold for integer ambiguity resolution [off]",
+" -w        widelane integer ambiguity resolution [off]",
 " -e        output x/y/z-ecef position [latitude/longitude/height]",
 " -a        output e/n/u-baseline [latitude/longitude/height]",
 " -n        output NMEA-0183 GGA sentence [off]",
@@ -156,7 +157,7 @@ int main(int argc, char **argv)
         else if (!strcmp(argv[i],"-c")) prcopt.soltype=2;
         else if (!strcmp(argv[i],"-i")) prcopt.modear=2;
         else if (!strcmp(argv[i],"-h")) {
-            prcopt.modear=3;
+            if (prcopt.modear!=ARMODE_WL) prcopt.modear=3;
             prcopt.wlmodear=1;
         }
         else if (!strcmp(argv[i],"-t")) solopt.timef=1;

--- a/app/rnx2rtkp/rnx2rtkp.c
+++ b/app/rnx2rtkp/rnx2rtkp.c
@@ -162,8 +162,8 @@ int main(int argc, char **argv)
         else if (!strcmp(argv[i],"-a")) solopt.posf=SOLF_ENU;
         else if (!strcmp(argv[i],"-n")) solopt.posf=SOLF_NMEA;
         else if (!strcmp(argv[i],"-g")) solopt.degf=1;
-	else if (!strcmp(argv[i],"-w")) { /* enable widelane mode */
-          prcopt.modear=ARMODE_WL;
+	    else if (!strcmp(argv[i],"-w")) { /* enable widelane mode */
+            prcopt.modear=ARMODE_WL;
         }
         else if (!strcmp(argv[i],"-r")&&i+3<argc) {
             prcopt.refpos=prcopt.rovpos=0;

--- a/app/rnx2rtkp/rnx2rtkp.c
+++ b/app/rnx2rtkp/rnx2rtkp.c
@@ -162,6 +162,9 @@ int main(int argc, char **argv)
         else if (!strcmp(argv[i],"-a")) solopt.posf=SOLF_ENU;
         else if (!strcmp(argv[i],"-n")) solopt.posf=SOLF_NMEA;
         else if (!strcmp(argv[i],"-g")) solopt.degf=1;
+	else if (!strcmp(argv[i],"-w")) { /* enable widelane mode */
+          prcopt.modear=ARMODE_WL;
+        }
         else if (!strcmp(argv[i],"-r")&&i+3<argc) {
             prcopt.refpos=prcopt.rovpos=0;
             for (j=0;j<3;j++) prcopt.rb[j]=atof(argv[++i]);

--- a/app/rnx2rtkp/rnx2rtkp.c
+++ b/app/rnx2rtkp/rnx2rtkp.c
@@ -155,7 +155,10 @@ int main(int argc, char **argv)
         else if (!strcmp(argv[i],"-b")) prcopt.soltype=1;
         else if (!strcmp(argv[i],"-c")) prcopt.soltype=2;
         else if (!strcmp(argv[i],"-i")) prcopt.modear=2;
-        else if (!strcmp(argv[i],"-h")) prcopt.modear=3;
+        else if (!strcmp(argv[i],"-h")) {
+            prcopt.modear=3;
+            prcopt.wlmodear=1;
+        }
         else if (!strcmp(argv[i],"-t")) solopt.timef=1;
         else if (!strcmp(argv[i],"-u")) solopt.times=TIMES_UTC;
         else if (!strcmp(argv[i],"-e")) solopt.posf=SOLF_XYZ;

--- a/src/options.c
+++ b/src/options.c
@@ -55,7 +55,7 @@ static char snrmask_[NFREQ][1024];
 #define GEOOPT  "0:internal,1:egm96,2:egm08_2.5,3:egm08_1,4:gsi2000"
 #define STAOPT  "0:all,1:single"
 #define STSOPT  "0:off,1:state,2:residual"
-#define ARMOPT  "0:off,1:continuous,2:instantaneous,3:fix-and-hold"
+#define ARMOPT  "0:off,1:continuous,2:instantaneous,3:fix-and-hold,4:WLNL,5:TCAR,6:wide-lane"
 #define POSOPT  "0:llh,1:xyz,2:single,3:posfile,4:rinexhead,5:rtcm,6:raw"
 #define TIDEOPT "0:off,1:on,2:otl"
 #define PHWOPT  "0:off,1:on,2:precise"

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -2940,9 +2940,9 @@ extern void traceobs(int level, const obsd_t *obs, int n)
     for (i=0;i<n;i++) {
         time2str(obs[i].time,str,3);
         satno2id(obs[i].sat,id);
-        fprintf(fp_trace," (%2d) %s %-3s rcv%d %13.3f %13.3f %13.3f %13.3f %d %d %d %d %3.1f %3.1f\n",
-              i+1,str,id,obs[i].rcv,obs[i].L[0],obs[i].L[1],obs[i].P[0],
-              obs[i].P[1],obs[i].LLI[0],obs[i].LLI[1],obs[i].code[0],
+        fprintf(fp_trace," (%2d) %s %-3s rcv%d %13.3f %13.3f %13.3f %13.3f %13.3f %13.3f %d %d %d %d %3.1f %3.1f\n",
+              i+1,str,id,obs[i].rcv,obs[i].L[0],obs[i].L[1],obs[i].L[2],obs[i].P[0],
+              obs[i].P[1],obs[i].P[2],obs[i].LLI[0],obs[i].LLI[1],obs[i].code[0],
               obs[i].code[1],obs[i].SNR[0]*0.25,obs[i].SNR[1]*0.25);
     }
     fflush(fp_trace);

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -190,7 +190,7 @@ const double lam_carr[MAXFREQ]={ /* carrier wave length (m) */
 const prcopt_t prcopt_default={ /* defaults processing options */
     PMODE_SINGLE,0,2,SYS_GPS,   /* mode,soltype,nf,navsys */
     15.0*D2R,{{0,0}},           /* elmin,snrmask */
-    0,1,1,1,                    /* sateph,modear,glomodear,bdsmodear */
+    0,1,0,1,1,                    /* sateph,modear,wlmodear,glomodear,bdsmodear */
     5,0,10,1,                   /* maxout,minlock,minfix,armaxiter */
     0,0,0,0,                    /* estion,esttrop,dynamics,tidecorr */
     1,0,0,0,0,                  /* niter,codesmooth,intpref,sbascorr,sbassatsel */

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1043,6 +1043,7 @@ typedef struct {        /* processing options type */
     snrmask_t snrmask;  /* SNR mask */
     int sateph;         /* satellite ephemeris/clock (EPHOPT_???) */
     int modear;         /* AR mode (0:off,1:continuous,2:instantaneous,3:fix and hold,4:ppp-ar) */
+    int wlmodear;       /* wide lane AR fix and hold (0: off, 1: on) */
     int glomodear;      /* GLONASS AR mode (0:off,1:on,2:auto cal,3:ext cal) */
     int bdsmodear;      /* BeiDou AR mode (0:off,1:on) */
     int maxout;         /* obs outage count to reset bias */

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1179,7 +1179,7 @@ typedef struct {        /* satellite status type */
     double resc[NFREQ]; /* residuals of carrier-phase (m) */
     unsigned char vsat[NFREQ]; /* valid satellite flag */
     unsigned char snr [NFREQ]; /* signal strength (0.25 dBHz) */
-    unsigned char fix [NFREQ]; /* ambiguity fix flag (1:fix,2:float,3:hold) */
+    unsigned char fix [NFREQ]; /* ambiguity fix flag (1:float,2:fix,3:hold) */
     unsigned char slip[NFREQ]; /* cycle-slip flag */
     unsigned char half[NFREQ]; /* half-cycle valid flag */
     int lock [NFREQ];   /* lock counter of phase */

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -399,6 +399,7 @@ extern "C" {
 #define ARMODE_FIXHOLD 3                /* AR mode: fix and hold */
 #define ARMODE_WLNL 4                   /* AR mode: wide lane/narrow lane */
 #define ARMODE_TCAR 5                   /* AR mode: triple carrier ar */
+#define ARMODE_WL   6                   /* AR mode: wide lane ar */
 
 #define SBSOPT_LCORR 1                  /* SBAS option: long term correction */
 #define SBSOPT_FCORR 2                  /* SBAS option: fast correction */

--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -1568,7 +1568,7 @@ static int dd_wl_mat(rtk_t *rtk, double *D)
 static int resamb_WL(rtk_t *rtk, double *bias, double *xa)
 {
     prcopt_t *opt=&rtk->opt;
-    int i,j,ny,nb,info,nx=rtk->nx,na=rtk->na,k,ns,row,col;
+    int i,j,ny,nb,info,nx=rtk->nx,na=rtk->na;
     double *D,*DP,*y,*Qy,*b,*db,*Qb,*Qab,*QQ,s[2];
 
     trace(3,"resamb_WL : nx=%d\n",nx);
@@ -1585,7 +1585,7 @@ static int resamb_WL(rtk_t *rtk, double *bias, double *xa)
         free(D);
         return 0;
     };
-    trace(1,"na = %d, nb = %d\n", na, nb);
+    trace(2,"na = %d, nb = %d\n", na, nb);
     ny=na+nb; y=mat(ny,1); Qy=mat(ny,ny); DP=mat(ny,nx);
     b=mat(nb,2); db=mat(nb,1); Qb=mat(nb,nb); Qab=mat(na,nb); QQ=mat(na,nb);
 
@@ -1633,7 +1633,7 @@ static int resamb_WL(rtk_t *rtk, double *bias, double *xa)
                       nb,s[0]==0.0?0.0:s[1]/s[0],s[0],s[1]);
 
                 /* restore single-differenced ambiguity */
-                trace(1,"nb = %d\n",nb);
+                trace(2,"nb = %d\n",nb);
                 restamb(rtk,bias,nb,xa);
             }
             else nb=0;
@@ -1902,7 +1902,7 @@ static int relpos(rtk_t *rtk, const obsd_t *obs, int nu, int nr,
     /* resolve integer ambiguity by WL */
     else if (stat!=SOLQ_NONE&&rtk->opt.modear==ARMODE_WL) {
         if (resamb_WL(rtk,bias,xa)>1) {
-            holdamb(rtk,xa);
+            if (rtk->opt.wlmodear==1) holdamb(rtk,xa);
             stat=SOLQ_FIX;
         }
     }

--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -44,6 +44,7 @@
 *           2019/08/19 1.15 fix bug on return value of resamb_LAMBDA()
 *-----------------------------------------------------------------------------*/
 #include <stdarg.h>
+#include <assert.h>
 #include "rtklib.h"
 
 /* constants/macros ----------------------------------------------------------*/
@@ -1373,7 +1374,7 @@ static int ddmat(rtk_t *rtk, double *D)
 /* restore single-differenced ambiguity --------------------------------------*/
 static void restamb(rtk_t *rtk, const double *bias, int nb, double *xa)
 {
-    int i,n,m,f,index[MAXSAT],index0[MAXSAT],nv=0,nf=NF(&rtk->opt);
+    int i,n,m,f,index[MAXSAT]={0},index0[MAXSAT]={0},nv=0,nf=NF(&rtk->opt);
 
     trace(3,"restamb :\n");
 
@@ -1395,8 +1396,11 @@ static void restamb(rtk_t *rtk, const double *bias, int nb, double *xa)
 
         /* in case of ARMODE_WL, use float ambiguity for L1 */
         if (rtk->opt.modear==ARMODE_WL) {
-            for (i=0;i<n;i++) {
-                if (i!=0&&f!=0) {
+            for (i=1;i<n;i++) {
+                if (f>0&&index0[0]!=0&&
+                    index0[i]!=0&&
+                    index[0] !=0&&
+                    index[i] !=0) {
                     xa[index[i]]=bias[nv++]-(xa[index0[0]]-xa[index0[i]]-xa[index[0]]);
                 }
             }
@@ -1409,12 +1413,14 @@ static void restamb(rtk_t *rtk, const double *bias, int nb, double *xa)
             }
         }
     }
+    assert(nv==nb);
 }
 /* hold integer ambiguity ----------------------------------------------------*/
 static void holdamb(rtk_t *rtk, const double *xa)
 {
     double *v,*H,*R;
-    int i,n,m,f,info,index[MAXSAT],index0[MAXSAT],nb=rtk->nx-rtk->na,nv=0,nf=NF(&rtk->opt);
+    int i,n,m,f,info,index[MAXSAT]={0},index0[MAXSAT]={0},nb=rtk->nx-rtk->na;
+    int nv=0,nf=NF(&rtk->opt);
 
     trace(3,"holdamb :\n");
 
@@ -1435,10 +1441,18 @@ static void holdamb(rtk_t *rtk, const double *xa)
         }
         /* constraint to fixed ambiguity */
         if (rtk->opt.modear==ARMODE_WL) {
-            if (f!=0) {
-                for (i=1;i<n;i++) {
-                    v[nv]=xa[index0[0]]-xa[index0[i]]-(xa[index[0]]-xa[index[i]])
-                            -(rtk->x[index0[0]]-rtk->x[index0[i]]-(rtk->x[index[0]]-rtk->x[index[i]]));
+            for (i=1;i<n;i++) {
+                if (f>0&&index0[0]!=0&&
+                    index0[i]!=0&&
+                    index[0] !=0&&
+                    index[i] !=0) {
+                    v[nv]=xa[index0[0]]-xa[index0[i]]
+                            -(xa[index[0]]-xa[index[i]])
+                            -(rtk->x[index0[0]]-rtk->x[index0[i]]
+                            -(rtk->x[index[0]]-rtk->x[index[i]]));
+
+                    trace(3,"hold_amb = %lf \n",xa[index0[0]]-xa[index0[i]]
+                                                -(xa[index[0]]-xa[index[i]]));
 
                     H[index[0]+nv*rtk->nx]= -1.0;
                     H[index[i]+nv*rtk->nx]=1.0;
@@ -1449,7 +1463,8 @@ static void holdamb(rtk_t *rtk, const double *xa)
             }
         } else {
             for (i=1;i<n;i++) {
-                v[nv]=(xa[index[0]]-xa[index[i]])-(rtk->x[index[0]]-rtk->x[index[i]]);
+                v[nv]=(xa[index[0]]-xa[index[i]])
+                        -(rtk->x[index[0]]-rtk->x[index[i]]);
 
                 H[index[0]+nv*rtk->nx]= 1.0;
                 H[index[i]+nv*rtk->nx]=-1.0;
@@ -1469,94 +1484,130 @@ static void holdamb(rtk_t *rtk, const double *xa)
     }
     free(v); free(H);
 }
-/* wide-lane transformation matrix (T) --------------------*/
-static void wlmat(rtk_t *rtk, double *T, int nb)
-{
-    int i,j,k,na=rtk->na,nf=NF(&rtk->opt),row,col,ns;
 
-    trace(3,"wlmat   :\n");
-    /* form wide-lane transformation matrix */
-    ns=nb/nf;
-    row=na+ns;
-    col=na+nb;
-    for(i=0;i<na;i++) T[i+i*row]=1.0;
-    for (k=0;k<nf;k++) {
-        for (i=0;i<ns;i++) {
-            for (j=0;j<ns;j++) {
-                if (i==j) {
-                    T[na*row+(i+na)+j*row+k*ns*row] = k==0?1.0:-1.0;
-                }
+/* single to double-differenced wide-lane transformation matrix (D') ---------*/
+static int dd_wl_mat(rtk_t *rtk, double *D)
+{
+    int i,j,k,m,f,nb=0,nx=rtk->nx,na=rtk->na,nf=NF(&rtk->opt),nofix;
+
+    trace(3,"dd_wl_mat   :\n");
+
+    for (i=0;i<MAXSAT;i++) for (j=0;j<NFREQ;j++) {
+        rtk->ssat[i].fix[j]=0;
+    }
+    for (i=0;i<na;i++) D[i+i*nx]=1.0;
+
+    for (m=0;m<5;m++) { /* m=0:gps/sbs,1:glo,2:gal,3:bds,4:qzs */
+
+        nofix=(m==1&&rtk->opt.glomodear==0)||(m==3&&rtk->opt.bdsmodear==0);
+        if (nofix) {
+            continue;
+        }
+
+        k=na;
+        f=nf==2?1:2;
+        for (i=k;i<k+MAXSAT;i++) {
+            if (rtk->x[i]==0.0||
+                rtk->x[i+f*MAXSAT]==0.0||
+                !test_sys(rtk->ssat[i-k].sys,m)||
+                !rtk->ssat[i-k].vsat[0]||
+                !rtk->ssat[i-k].half[0]||
+                !rtk->ssat[i-k].vsat[f]||
+                !rtk->ssat[i-k].half[f]) {
+                    continue;
+            }
+            if (rtk->ssat[i-k].lock[0]>0&&
+                rtk->ssat[i-k].lock[f]>0&&
+                !(rtk->ssat[i-k].slip[f]&2)&&
+                !(rtk->ssat[i-k].slip[0]&2)&&
+                rtk->ssat[i-k].azel[1]>=rtk->opt.elmaskar) {
+                rtk->ssat[i-k].fix[0]=2; /* fix */
+                rtk->ssat[i-k].fix[f]=2; /* fix */
+                break;
+            }
+            else {
+                rtk->ssat[i-k].fix[0]=1;
+                rtk->ssat[i-k].fix[f]=1;
+            }
+        }
+
+        for (j=k;j<k+MAXSAT;j++) {
+            if (i==j||
+                rtk->x[j]==0.0||
+                rtk->x[j+f*MAXSAT]==0.0||
+                !test_sys(rtk->ssat[j-k].sys,m)||
+                !rtk->ssat[j-k].vsat[0]||
+                !rtk->ssat[j-k].vsat[f]) {
+                continue;
+            }
+            if (rtk->ssat[j-k].lock[0]>0&&
+                rtk->ssat[j-k].lock[f]>0&&
+                !(rtk->ssat[j-k].slip[0]&2)&&
+                !(rtk->ssat[j-k].slip[f]&2)&&
+                rtk->ssat[j-k].azel[1]>=rtk->opt.elmaskar) {
+                D[i+(na+nb)*nx]= 1.0;
+                D[i+f*MAXSAT+(na+nb)*nx]=-1.0;
+                D[j+(na+nb)*nx]=-1.0;
+                D[j+f*MAXSAT+(na+nb)*nx]=1.0;
+                nb++;
+                rtk->ssat[j-k].fix[f]=2; /* fix */
+                rtk->ssat[j-k].fix[0]=2; /* fix */
+            }
+            else {
+                rtk->ssat[j-k].fix[0]=1;
+                rtk->ssat[j-k].fix[f]=1;
             }
         }
     }
-    trace(3,"T=\n"); tracemat(3,T,row,col,2,0);
 
-    return;
+    trace(4,"Dw=\n"); tracemat(4,D,nx,na+nb,2,0);
+    return nb;
 }
+
 /* resolve integer ambiguity by LAMBDA ---------------------------------------*/
 static int resamb_WL(rtk_t *rtk, double *bias, double *xa)
 {
     prcopt_t *opt=&rtk->opt;
     int i,j,ny,nb,info,nx=rtk->nx,na=rtk->na,k,ns,row,col;
     double *D,*DP,*y,*Qy,*b,*db,*Qb,*Qab,*QQ,s[2];
-    double *T,*Qw,*xw,*Qw1;
 
     trace(3,"resamb_WL : nx=%d\n",nx);
 
     rtk->sol.ratio=0.0;
 
-    if (rtk->opt.mode<=PMODE_DGPS||rtk->opt.modear==ARMODE_OFF||
-        rtk->opt.thresar[0]<1.0) {
+    if (rtk->opt.modear!=ARMODE_WL||rtk->opt.thresar[0]<1.0||rtk->opt.nf<2) {
         return 0;
     }
-    /* single to double-difference transformation matrix (D') */
+    /* single to double-differenced wide-lane transformation matrix (D') */
     D=zeros(nx,nx);
-    if ((nb=ddmat(rtk,D))<=0) {
-        errmsg(rtk,"no valid double-difference\n");
+    if ((nb=dd_wl_mat(rtk,D))<=0) {
+        errmsg(rtk,"no valid double, wide-lane difference\n");
         free(D);
         return 0;
-    }
+    };
+    trace(1,"na = %d, nb = %d\n", na, nb);
     ny=na+nb; y=mat(ny,1); Qy=mat(ny,ny); DP=mat(ny,nx);
+    b=mat(nb,2); db=mat(nb,1); Qb=mat(nb,nb); Qab=mat(na,nb); QQ=mat(na,nb);
 
-    /* transform single to double-differenced phase-bias (y=D'*x, Qy=D'*P*D) */
+    /* transform single to DD wide-lane phase-bias (y=D'*x, Qy=D'*P*D) */
     matmul("TN",ny, 1,nx,1.0,D ,rtk->x,0.0,y );
     matmul("TN",ny,nx,nx,1.0,D ,rtk->P,0.0,DP);
     matmul("NN",ny,ny,nx,1.0,DP,D     ,0.0,Qy);
 
+    /* phase-bias covariance (Qb) and real-parameters to bias covariance (Qab) */
+    for (i=0;i<nb;i++) for (j=0;j<nb;j++) Qb [i+j*nb]=Qy[na+i+(na+j)*ny];
+    for (i=0;i<na;i++) for (j=0;j<nb;j++) Qab[i+j*na]=Qy[   i+(na+j)*ny];
+
     trace(4,"N(0)="); tracemat(4,y+na,1,nb,10,3);
 
-    if (nb%rtk->opt.nf!=0) {    /* to do */
-        return 0;
-    }
-    ns=nb/rtk->opt.nf;
-    row=ns+na;
-    col=ny;
-
-    T=zeros(row,col); xw=mat(row,1); Qw=mat(row,row); Qw1=mat(row, col);
-    /* form wide-lane transformation matrix */
-    wlmat(rtk,T,nb);
-
-    /* transform double-differenced ambguities to wide-lane ambiguities */
-    matmul("NN",row,1,col,1.0,T ,y,0.0,xw);
-    matmul("NN",row,col,col,1.0,T ,Qy,0.0, Qw1);
-    matmul("NT",row,row,col,1.0,Qw1,T ,0.0,Qw);
-
-    b=mat(ns,2); db=mat(ns,1); Qb=mat(ns,ns); Qab=mat(na,ns); QQ=mat(na,ns);
-    /* phase-bias covariance (Qb) and real-parameters to bias covariance (Qab) */
-    for (i=0;i<ns;i++) for (j=0;j<ns;j++) Qb [i+j*ns]=Qw[na+i+(na+j)*row];
-    for (i=0;i<na;i++) for (j=0;j<ns;j++) Qab[i+j*na]=Qw[   i+(na+j)*row];
-
-    trace(4,"N(0)="); tracemat(4,xw+na,1,ns,10,3);
-
     /* lambda/mlambda integer least-square estimation */
-    if (!(info=lambda(ns,2,xw+na,Qb,b,s))) {
+    if (!(info=lambda(nb,2,y+na,Qb,b,s))) {
 
-        trace(4,"N(1)="); tracemat(4,b   ,1,ns,10,3);
-        trace(4,"N(2)="); tracemat(4,b+ns,1,ns,10,3);
+        trace(4,"N(1)="); tracemat(4,b   ,1,nb,10,3);
+        trace(4,"N(2)="); tracemat(4,b+nb,1,nb,10,3);
 
         rtk->sol.ratio=s[0]>0?(float)(s[1]/s[0]):0.0f;
         if (rtk->sol.ratio>999.9) rtk->sol.ratio=999.9f;
-        trace(4,"R-ratio= %lf threshold = %lf\n",s[1]/s[0],opt->thresar[0]);
 
         /* validation by popular ratio-test */
         if (s[0]<=0.0||s[1]/s[0]>=opt->thresar[0]) {
@@ -1566,38 +1617,41 @@ static int resamb_WL(rtk_t *rtk, double *bias, double *xa)
                 rtk->xa[i]=rtk->x[i];
                 for (j=0;j<na;j++) rtk->Pa[i+j*na]=rtk->P[i+j*nx];
             }
-            for (i=0;i<ns;i++) {
+            for (i=0;i<nb;i++) {
                 bias[i]=b[i];
-                xw[na+i]-=b[i];
+                y[na+i]-=b[i];
             }
-            if (!matinv(Qb,ns)) {
-                matmul("NN",ns,1,ns, 1.0,Qb ,xw+na,0.0,db);
-                matmul("NN",na,1,ns,-1.0,Qab,db  ,1.0,rtk->xa);
+            if (!matinv(Qb,nb)) {
+                matmul("NN",nb,1,nb, 1.0,Qb ,y+na,0.0,db);
+                matmul("NN",na,1,nb,-1.0,Qab,db  ,1.0,rtk->xa);
 
                 /* covariance of fixed solution (Qa=Qa-Qab*Qb^-1*Qab') */
-                matmul("NN",na,ns,ns, 1.0,Qab,Qb ,0.0,QQ);
-                matmul("NT",na,na,ns,-1.0,QQ ,Qab,1.0,rtk->Pa);
+                matmul("NN",na,nb,nb, 1.0,Qab,Qb ,0.0,QQ);
+                matmul("NT",na,na,nb,-1.0,QQ ,Qab,1.0,rtk->Pa);
 
-                trace(3,"resamb : validation ok (ns=%d ratio=%.2f s=%.2f/%.2f)\n",
-                      ns,s[0]==0.0?0.0:s[1]/s[0],s[0],s[1]);
+                trace(3,"resamb : validation ok (nb=%d ratio=%.2f s=%.2f/%.2f)\n",
+                      nb,s[0]==0.0?0.0:s[1]/s[0],s[0],s[1]);
 
-                /* restore single-differenced ambiguity (to do) */
-                restamb(rtk,bias,ns,xa);
+                /* restore single-differenced ambiguity */
+                trace(1,"nb = %d\n",nb);
+                restamb(rtk,bias,nb,xa);
             }
-            else ns=0;
+            else nb=0;
         }
         else { /* validation failed */
-            errmsg(rtk,"ambiguity validation failed (ns=%d ratio=%.2f s=%.2f/%.2f)\n",
-                   ns,s[1]/s[0],s[0],s[1]);
-            ns=0;
+            errmsg(rtk,"ambiguity validation failed (nb=%d ratio=%.2f s=%.2f/%.2f)\n",
+                   nb,s[1]/s[0],s[0],s[1]);
+            nb=0;
         }
     }
-
+    else {
+        errmsg(rtk,"lambda error (info=%d)\n",info);
+        nb=0;
+    }
     free(D); free(y); free(Qy); free(DP);
     free(b); free(db); free(Qb); free(Qab); free(QQ);
-    free(T); free(xw); free(Qw); free(Qw1);
 
-    return ns; /* number of ambiguities */
+    return nb; /* number of ambiguities */
 }
 /* resolve integer ambiguity by LAMBDA ---------------------------------------*/
 static int resamb_LAMBDA(rtk_t *rtk, double *bias, double *xa)


### PR DESCRIPTION
This PR implemented wide-lane support for GPS&GAL (potentially BDS-3) using L1/L5 frequencies. Satellites with dual-frequency L1/L5 observations will be attempted to fix the ambiguties.