### PR TITLE
Fix bug in handling of half cycle ambiguity flag in RTCM3 MSM messages

### DIFF
--- a/src/rtcm3.c
+++ b/src/rtcm3.c
@@ -1889,7 +1889,7 @@ static void save_msm_obs(rtcm_t *rtcm, int sys, msm_h_t *h, const double *r,
                     rtcm->obs.data[index].D[ind[k]]=(float)(-(rr[i]+rrf[j])/wl);
                 }
                 rtcm->obs.data[index].LLI[ind[k]]=
-                    lossoflock(rtcm,sat,ind[k],lock[j])+(half[j]?3:0);
+                    lossoflock(rtcm,sat,ind[k],lock[j])+(half[j]?2:0);
                 rtcm->obs.data[index].SNR [ind[k]]=(unsigned char)(cnr[j]*4.0);
                 rtcm->obs.data[index].code[ind[k]]=code[k];
             }


### PR DESCRIPTION
See https://github.com/tomojitakasu/RTKLIB/issues/636 for an explanation.  In short: bit 1 in the RINEX standard indicates "Half-cycle ambiguity/slip possible" whereas bit 0 indicates "Lost lock between previous and current observation"

This fix was cherry-picked from https://github.com/Aceinna/rtklib_aceinna/commit/3ac97c97f9c31bb04ba236fc345fe798c2b643f1