### PR TITLE
Use MSG_BASE_POS_ECEF to determine base station location

### DIFF
--- a/app/convbin/convbin.c
+++ b/app/convbin/convbin.c
@@ -75,6 +75,7 @@ static const char *help[]={
     "                  json      - Swift Navigation SBP-JSON",
     "     -ro opt,opt  receiver option(s) (use comma between multiple opt):",
     "                  CONVBASE  - convert base station observations",
+    "                  BASEPOS   - determine base station location from input file",
     "                  EPHALL    - include all ephemeris",
     "                  INVCP     - invert carrier phase polarity",
     "                  OBSALL    - include observations with RAIM flag set",

--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -658,6 +658,9 @@ static int scan_obstype(int format, char **files, int nf, rnxopt_t *opt,
         if (!open_strfile(str,files[m])) {
             continue;
         }
+        if (str->format==STRFMT_SBP||str->format==STRFMT_SBPJSON) {
+            if(str->raw.sbp.staid!=0) update_stas(stas,str);
+        }
         /* scan codes and station info in input file */
         while ((type=input_strfile(str))>=-1) {
 

--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -82,19 +82,9 @@ static const int navsys[]={     /* system codes */
 /* initialise a sbp_t --------------------------------------------------------*/
 static int init_sbp(sbp_t *sbp)
 {
-    int i;
-
     trace(3,"init_sbp:\n");
 
-    sbp->staid=0;
-    sbp->sta.name[0]=sbp->sta.marker[0]='\0';
-    sbp->sta.antdes[0]=sbp->sta.antsno[0]='\0';
-    sbp->sta.rectype[0]=sbp->sta.recver[0]=sbp->sta.recsno[0]='\0';
-    sbp->sta.antsetup=sbp->sta.itrf=sbp->sta.deltype=0;
-    for (i=0;i<3;i++) {
-        sbp->sta.pos[i]=sbp->sta.del[i]=0.0;
-    }
-    sbp->sta.hgt=0.0;
+    memset(sbp, 0, sizeof(sbp_t));
 
     return 1;
 }

--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -88,11 +88,6 @@ static int init_sbp(sbp_t *sbp)
 
     return 1;
 }
-/* free a sbp_t --------------------------------------------------------------*/
-static void free_sbp(sbp_t *sbp)
-{
-    // FIXME: free station list
-}
 /* convert rinex obs type ver.3 -> ver.2 -------------------------------------*/
 static void convcode(double ver, int sys, char *type)
 {
@@ -372,9 +367,6 @@ static void free_strfile(strfile_t *str)
     }
     else if (str->format<=MAXRCVFMT) {
         free_raw(&str->raw);
-        if (str->format==STRFMT_SBP||str->format==STRFMT_SBPJSON) {
-            free_sbp(&str->raw.sbp);
-        }
     }
     else if (str->format==STRFMT_RINEX) {
         free_rnxctr(&str->rnx);

--- a/src/rcv/swiftnav.c
+++ b/src/rcv/swiftnav.c
@@ -1419,6 +1419,8 @@ static int decode_base_pos_ecef(raw_t *raw) {
     return -1;
   }
 
+  if ((NULL == strstr(raw->opt, "BASEPOS"))) return 0;
+
   rr[0] = R8(puiTmp + 0);
   rr[1] = R8(puiTmp + 8);
   rr[2] = R8(puiTmp + 16);
@@ -1427,7 +1429,7 @@ static int decode_base_pos_ecef(raw_t *raw) {
      rr[1] == raw->sbp.sta.pos[1] &&
      rr[2] == raw->sbp.sta.pos[2]) {
     /* no change in position */
-    return -1;
+    return 0;
   }
 
   raw->sbp.staid++;

--- a/src/rcv/swiftnav.c
+++ b/src/rcv/swiftnav.c
@@ -1425,9 +1425,9 @@ static int decode_base_pos_ecef(raw_t *raw) {
   rr[1] = R8(puiTmp + 8);
   rr[2] = R8(puiTmp + 16);
 
-  if(rr[0] == raw->sbp.sta.pos[0] &&
-     rr[1] == raw->sbp.sta.pos[1] &&
-     rr[2] == raw->sbp.sta.pos[2]) {
+  if (rr[0] == raw->sbp.sta.pos[0] &&
+      rr[1] == raw->sbp.sta.pos[1] &&
+      rr[2] == raw->sbp.sta.pos[2]) {
     /* no change in position */
     return 0;
   }

--- a/src/rcv/swiftnav.c
+++ b/src/rcv/swiftnav.c
@@ -39,6 +39,8 @@
 #define ID_MSGIONGPS 0x0090    /* GPS ionospheric parameters */
 #define ID_MSG_SBAS_RAW 0x7777 /* SBAS data */
 
+#define ID_MSG_BASE_POS_ECEF 0x0048 /* Base station position in ECEF */
+
 #define SEC_DAY 86400.0
 
 /** Constant difference of Beidou time from GPS time */
@@ -1404,6 +1406,40 @@ static int decode_snav(raw_t *raw) {
   return 3;
 }
 
+/* decode base station position message --------------------------------------*/
+static int decode_base_pos_ecef(raw_t *raw) {
+  uint8_t *puiTmp = (raw->buff) + 6;
+  double rr[3];
+  int j;
+
+  trace(4, "%s: len=%d\n", __FUNCTION__, raw->len);
+
+  if ((raw->len) < 26) {
+    trace(2, "%s: frame length error: len=%d\n", __FUNCTION__, raw->len);
+    return -1;
+  }
+
+  rr[0] = R8(puiTmp + 0);
+  rr[1] = R8(puiTmp + 8);
+  rr[2] = R8(puiTmp + 16);
+
+  if(rr[0] == raw->sbp.sta.pos[0] &&
+     rr[1] == raw->sbp.sta.pos[1] &&
+     rr[2] == raw->sbp.sta.pos[2]) {
+    /* no change in position */
+    return -1;
+  }
+
+  raw->sbp.staid++;
+  raw->sbp.sta.deltype=0; /* xyz */
+  for (j=0;j<3;j++) {
+    raw->sbp.sta.pos[j]=rr[j];
+    raw->sbp.sta.del[j]=0.0;
+  }
+  raw->sbp.sta.hgt=0.0;
+  return 5;
+}
+
 /* decode SBF raw message --------------------------------------------------*/
 static int decode_sbp(raw_t *raw) {
   uint16_t crc, uCalcCrc;
@@ -1456,6 +1492,8 @@ static int decode_sbp(raw_t *raw) {
       return decode_gpsion(raw);
     case ID_MSG_SBAS_RAW:
       return decode_snav(raw);
+    case ID_MSG_BASE_POS_ECEF:
+      return decode_base_pos_ecef(raw);
     default:
       trace(3, "decode_sbp: unused frame type=%04x len=%d\n", type, raw->len);
       /* there are many more SBF blocks to be extracted */

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1226,6 +1226,11 @@ typedef struct half_cyc_tag {  /* half-cycle correction list type */
     struct half_cyc_tag *next; /* pointer to next correction */
 } half_cyc_t;
 
+typedef struct {
+    int staid;          /* station id */
+    sta_t sta;          /* station parameters */
+} sbp_t;
+
 typedef struct {        /* receiver raw data control type */
     gtime_t time;       /* message time */
     gtime_t tobs[MAXSAT][NFREQ+NEXOBS]; /* observation data time */
@@ -1256,6 +1261,9 @@ typedef struct {        /* receiver raw data control type */
 
     int format;         /* receiver stream format */
     void *rcv_data;     /* receiver dependent data */
+
+    /* only used for STRFMT_SBP and STRFMT_SBPJSON */
+    sbp_t sbp;          /* Swift Binary Protocol stream data */
 } raw_t;
 
 typedef struct {        /* stream type */


### PR DESCRIPTION
Add a new `BASEPOS` option for sbp2rinex.  If this option is specified, then the MSG_BASE_POS_ECEF SBP message will be used to determine the base station location.  The first value will be written into the header of the RINEX file (e.g. ` -2726598.3898 -4315438.3711  3811232.7316                  APPROX POSITION XYZ`).  Subsequent changes will be stored in the observation file as "new site occupation" events, e.g.:

```
                               3  6
station ID:   23                                            COMMENT             
0023                                                        MARKER NAME         
                                                            REC # / TYPE / VERS 
                                                            ANT # / TYPE        
 -2694256.6524 -4264245.9688  3890436.5507                  APPROX POSITION XYZ 
        0.0000        0.0000        0.0000                  ANTENNA: DELTA H/E/N
```