### PR TITLE
Fix compilation of rnx2rtcm

### DIFF
--- a/src/rinex.c
+++ b/src/rinex.c
@@ -1854,6 +1854,7 @@ extern int input_rnxctr(rnxctr_t *rnx, FILE *fp)
         case 'H': sys=SYS_SBS ; break;
         case 'L': sys=SYS_GAL ; break; /* extension */
         case 'J': sys=SYS_QZS ; break; /* extension */
+        case 'C': sys=SYS_CMP ; break; /* extension */
         default: return 0;
     }
     if ((stat=readrnxnavb(fp,rnx->opt,rnx->ver,sys,&type,&eph,&geph,&seph))<=0) {

--- a/util/rnx2rtcm/makefile
+++ b/util/rnx2rtcm/makefile
@@ -2,10 +2,10 @@
 
 BINDIR = /usr/local/bin
 SRC    = ../../src
-CFLAGS = -Wall -O3 -ansi -pedantic -I$(SRC) -DTRACE -DENAGLO -DENAGAL -DENAQZS -DNFREQ=3 -DNEXOBS=3
+CFLAGS = -Wall -O3 -pedantic -I$(SRC) -DTRACE -DENAGLO -DENAGAL -DENAQZS -DNFREQ=3 -DNEXOBS=3
 LDLIBS  = -lm
 
-rnx2rtcm   : rnx2rtcm.o rtkcmn.o rinex.o rtcm.o rtcm2.o rtcm3.o rtcm3e.o
+rnx2rtcm   : rnx2rtcm.o rtkcmn.o rinex.o rtcm.o rtcm2.o rtcm3.o rtcm3e.o ephemeris.o preceph.o sbas.o
 
 rnx2rtcm.o : rnx2rtcm.c
 	$(CC) -c $(CFLAGS) rnx2rtcm.c
@@ -21,6 +21,12 @@ rtcm3.o    : $(SRC)/rtcm3.c
 	$(CC) -c $(CFLAGS) $(SRC)/rtcm3.c
 rtcm3e.o   : $(SRC)/rtcm3e.c
 	$(CC) -c $(CFLAGS) $(SRC)/rtcm3e.c
+ephemeris.o : $(SRC)/ephemeris.c
+	$(CC) -c $(CFLAGS) $(SRC)/ephemeris.c
+preceph.o : $(SRC)/preceph.c
+	$(CC) -c $(CFLAGS) $(SRC)/preceph.c
+sbas.o : $(SRC)/sbas.c
+	$(CC) -c $(CFLAGS) $(SRC)/sbas.c
 
 install:
 	cp rnx2rtcm $(BINDIR)

--- a/util/rnx2rtcm/makefile
+++ b/util/rnx2rtcm/makefile
@@ -2,7 +2,7 @@
 
 BINDIR = /usr/local/bin
 SRC    = ../../src
-CFLAGS = -Wall -O3 -pedantic -I$(SRC) -DTRACE -DENAGLO -DENAGAL -DENAQZS -DNFREQ=3 -DNEXOBS=3
+CFLAGS = -Wall -O3 -pedantic -I$(SRC) -DTRACE -DENAGLO -DENAGAL -DENAQZS -DENACMP -DNFREQ=3 -DNEXOBS=3
 LDLIBS  = -lm
 
 rnx2rtcm   : rnx2rtcm.o rtkcmn.o rinex.o rtcm.o rtcm2.o rtcm3.o rtcm3e.o ephemeris.o preceph.o sbas.o

--- a/util/rnx2rtcm/rnx2rtcm.c
+++ b/util/rnx2rtcm/rnx2rtcm.c
@@ -61,7 +61,7 @@ static void gen_rtcm_obs(rtcm_t *rtcm, const int *type, int n, FILE *fp)
     for (i=0;i<n;i++) {
         if (is_nav(type[i])||is_gnav(type[i])||is_ant(type[i])) continue;
         
-        if (!gen_rtcm3(rtcm,type[i],i!=j)) continue;
+        if (!gen_rtcm3(rtcm,type[i],0,i!=j)) continue;
         if (fwrite(rtcm->buff,rtcm->nbyte,1,fp)<1) break;
     }
 }
@@ -82,7 +82,7 @@ static void gen_rtcm_nav(gtime_t time, rtcm_t *rtcm, const nav_t *nav,
         for (j=0;j<n;j++) {
             if (!is_nav(type[j])) continue;
             
-            if (!gen_rtcm3(rtcm,type[j],0)) continue;
+            if (!gen_rtcm3(rtcm,type[j],0,0)) continue;
             if (fwrite(rtcm->buff,rtcm->nbyte,1,fp)<1) break;
         }
         index[0]=i+1;
@@ -99,7 +99,7 @@ static void gen_rtcm_nav(gtime_t time, rtcm_t *rtcm, const nav_t *nav,
         for (j=0;j<n;j++) {
             if (!is_gnav(type[j])) continue;
             
-            if (!gen_rtcm3(rtcm,type[j],0)) continue;
+            if (!gen_rtcm3(rtcm,type[j],0,0)) continue;
             if (fwrite(rtcm->buff,rtcm->nbyte,1,fp)<1) break;
         }
         index[1]=i+1;
@@ -113,7 +113,7 @@ static void gen_rtcm_ant(rtcm_t *rtcm, const int *type, int n, FILE *fp)
     for (i=0;i<n;i++) {
         if (!is_ant(type[i])) continue;
         
-        if (!gen_rtcm3(rtcm,type[i],0)) continue;
+        if (!gen_rtcm3(rtcm,type[i],0,0)) continue;
         if (fwrite(rtcm->buff,rtcm->nbyte,1,fp)<1) break;
     }
 }

--- a/util/rnx2rtcm/rnx2rtcm.c
+++ b/util/rnx2rtcm/rnx2rtcm.c
@@ -37,7 +37,7 @@ static void print_help(void)
 /* test rtcm nav data --------------------------------------------------------*/
 static int is_nav(int type)
 {
-    return type==1019||type==1044||type==1045||type==1046;
+    return type==1019||type==1042||type==1044||type==1045||type==1046;
 }
 /* test rtcm gnav data -------------------------------------------------------*/
 static int is_gnav(int type)


### PR DESCRIPTION
Compilation of rnx2rtcm broke when we upgraded to v2.4.3-b34.  This breakage originates from upstream: rnx2rtcm compiles when using the upstream version of v2.4.3-b33, but not with the upstream version of v2.4.3-b34.
Also fix support for converting GAL F/NAV and BDS ephemerides.