### PR TITLE
Zero number of observations when decoding MSM observations containing 0 satellites

### DIFF
--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -243,6 +243,7 @@ static int input_strfile(strfile_t *str)
     trace(4,"input_strfile:\n");
     
     if (str->format==STRFMT_RTCM2) {
+        str->rtcm.obs.n=0;
         if ((type=input_rtcm2f(&str->rtcm,str->fp))>=1) {
             str->time=str->rtcm.time;
             str->ephsat=str->rtcm.ephsat;
@@ -251,6 +252,7 @@ static int input_strfile(strfile_t *str)
         }
     }
     else if (str->format==STRFMT_RTCM3) {
+        str->rtcm.obs.n=0;
         if ((type=input_rtcm3f(&str->rtcm,str->fp))>=1) {
             str->time=str->rtcm.time;
             str->ephsat=str->rtcm.ephsat;
@@ -259,6 +261,7 @@ static int input_strfile(strfile_t *str)
         }
     }
     else if (str->format<=MAXRCVFMT) {
+        str->raw.obs.n=0;
         if ((type=input_rawf(&str->raw,str->format,str->fp))>=1) {
             str->time=str->raw.time;
             str->ephsat=str->raw.ephsat;
@@ -271,6 +274,7 @@ static int input_strfile(strfile_t *str)
         }
     }
     else if (str->format==STRFMT_RINEX) {
+        str->rnx.obs.n=0;
         if ((type=input_rnxctr(&str->rnx,str->fp))>=1) {
             str->time=str->rnx.time;
             str->ephsat=str->rnx.ephsat;

--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -1010,7 +1010,7 @@ static void convobs(FILE **ofp, rnxopt_t *opt, strfile_t *str, int *n,
     
     if (!ofp[0]||str->obs->n<=0) return;
     
-    time=str->obs->data[0].time;
+    time=str->time;
     
     /* avoid duplicated data by multiple files handover */
     if (tend->time&&timediff(time,*tend)<opt->ttol) return;

--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -1010,7 +1010,7 @@ static void convobs(FILE **ofp, rnxopt_t *opt, strfile_t *str, int *n,
     
     if (!ofp[0]||str->obs->n<=0) return;
     
-    time=str->time;
+    time=str->obs->data[0].time;
     
     /* avoid duplicated data by multiple files handover */
     if (tend->time&&timediff(time,*tend)<opt->ttol) return;

--- a/src/rtcm3.c
+++ b/src/rtcm3.c
@@ -2036,7 +2036,6 @@ static void save_msm_obs(rtcm_t *rtcm, int sys, msm_h_t *h, const double *r,
     /* get signal index */
     sigindex(sys,code,h->nsig,rtcm->opt,idx);
     
-    rtcm->obs.n=0;
     for (i=j=0;i<h->nsat;i++) {
         
         prn=h->sats[i];

--- a/src/rtcm3.c
+++ b/src/rtcm3.c
@@ -2036,6 +2036,7 @@ static void save_msm_obs(rtcm_t *rtcm, int sys, msm_h_t *h, const double *r,
     /* get signal index */
     sigindex(sys,code,h->nsig,rtcm->opt,idx);
     
+    rtcm->obs.n=0;
     for (i=j=0;i<h->nsat;i++) {
         
         prn=h->sats[i];


### PR DESCRIPTION
If there are no satellites/signals present in a set of MSM observation messages then `h->nsat` will be zero.  In this case, the `for` loop will never run, meaning that `obsindex()` will never get called and so `rtcm->obs.n` will never get updated.  This means that the number of observations will remain set to the last non-zero number of observations, which can trigger a chain reaction of unexpected events.