### PR TITLE
Add Claude reusable review workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,18 @@
+name: Claude
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened]
+
+jobs:
+  claude_review:
+    uses: swift-nav/swift-context-hub/.github/workflows/claude.yml@main
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+      SSH_KEY: ${{ secrets.SSH_KEY }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude.yml`; calls the `swift-context-hub` reusable workflow at `@main`.
- Enables `@claude` and `@claude review` on PRs/issues; auto-review on approval.

## Requirements
- Repo secrets `ANTHROPIC_API_KEY` and `SSH_KEY` must be configured.

## Test plan
- Comment `@claude review` on a PR; reviewer posts inline comments.
